### PR TITLE
New Initial Parent Directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.pdf
 *.png
 *.txt
+.files/**

--- a/store.sh
+++ b/store.sh
@@ -2,8 +2,17 @@
 
 # The whole LabBook directory system is built within this
 # directory. This is defined at the beginning and not changed
-PARENT=""
-
+get_script_dir () {
+	SOURCE="${BASH_SOURCE[0]}"
+	while [ -h "$SOURCE" ]; do
+		DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+		SOURCE="$( readlink "$SOURCE" )"
+		[[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
+	done
+	DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+	echo "$DIR"
+}
+PARENT="$(get_script_dir)/.files"
 # Set Date for today
 Define_Today() {
 	read -r YEAR MONTH DAY MONTH_NUM <<<$(date +%Y\ %b\ %d\ %m)


### PR DESCRIPTION
This just changes the default parent directory from null to a hidden folder in the same directory as the script. Since most users will redefine it anyway it's probably not important but I think it's slightly better than having no directory defined. Also added a line to the .gitignore to ignore files in this hidden folder. The directory detection script is robust and should work even with symbolic links.